### PR TITLE
[ENH] Explain model: Display Discrete variables in two rows

### DIFF
--- a/orangecontrib/explain/widgets/owexplainmodel.py
+++ b/orangecontrib/explain/widgets/owexplainmodel.py
@@ -149,7 +149,7 @@ class ViolinItem(QGraphicsWidget):
             item.setX(_x)
             item.setY(_y)
             item.setRect(0, 0, self.POINT_R, self.POINT_R)
-            color = QColor(*colors.pop())
+            color = QColor(*colors.pop().astype(int))
             item.setPen(QPen(color))
             item.setBrush(QBrush(color))
             self.__group.addToGroup(item)

--- a/orangecontrib/explain/widgets/owexplainmodel.py
+++ b/orangecontrib/explain/widgets/owexplainmodel.py
@@ -134,12 +134,16 @@ class Legend(QGraphicsWidget):
 class VariableItem(QGraphicsItemGroup):
     MAX_ATTR_LEN = 25
     MAX_LABEL_LEN = 150
+    VALUE_FONT_SETTING = {Updater.SIZE_LABEL: 12,
+                          Updater.IS_ITALIC_LABEL: True}
 
     def __init__(self, parent, label: str):
         self.__name: str = None
         self.__value: Optional[str] = None
         self.__name_item = QGraphicsSimpleTextItem()
         self.__value_item = QGraphicsSimpleTextItem()
+        font = Updater.change_font(QFont(), self.VALUE_FONT_SETTING)
+        self.__value_item.setFont(font)
         self.__max_len = self.MAX_LABEL_LEN
         super().__init__(parent)
         self._set_data(label)
@@ -369,7 +373,9 @@ class ParameterSetter(CommonParameterSetter):
     LEGEND_HEIGHT = "Legend height"
 
     def __init__(self, parent):
-        self.value_label_font = QFont()
+        self.value_label_font = Updater.change_font(
+            QFont(), VariableItem.VALUE_FONT_SETTING
+        )
         self.label_len_setting = {
             self.LABEL_LENGTH: VariableItem.MAX_LABEL_LEN
         }
@@ -412,11 +418,17 @@ class ParameterSetter(CommonParameterSetter):
         def update_legend_bar(**settings):
             self.legend.set_bar(settings[self.LEGEND_HEIGHT])
 
+        font_size = VariableItem.VALUE_FONT_SETTING[Updater.SIZE_LABEL]
+        is_italic = VariableItem.VALUE_FONT_SETTING[Updater.IS_ITALIC_LABEL]
+        value_font_setting = {
+            Updater.SIZE_LABEL: (range(4, 50), font_size),
+            Updater.IS_ITALIC_LABEL: (None, is_italic)
+        }
         self.initial_settings = {
             self.LABELS_BOX: {
                 self.FONT_FAMILY_LABEL: self.FONT_FAMILY_SETTING,
                 self.VAR_LABEL: self.FONT_SETTING,
-                self.VAL_LABEL: self.FONT_SETTING,
+                self.VAL_LABEL: value_font_setting,
                 self.AXIS_TITLE_LABEL: self.FONT_SETTING,
                 self.AXIS_TICKS_LABEL: self.FONT_SETTING,
                 self.LEGEND_LABEL: self.FONT_SETTING,

--- a/orangecontrib/explain/widgets/tests/test_owexplainmodel.py
+++ b/orangecontrib/explain/widgets/tests/test_owexplainmodel.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from AnyQt.QtCore import Qt, QPoint
 from AnyQt.QtTest import QTest
-from AnyQt.QtWidgets import QGraphicsGridLayout, QGraphicsSimpleTextItem
+from AnyQt.QtWidgets import QGraphicsGridLayout
 
 import pyqtgraph as pg
 
@@ -22,7 +22,7 @@ from Orange.data import Table, Domain
 from Orange.regression import RandomForestRegressionLearner
 
 from orangecontrib.explain.widgets.owexplainmodel import OWExplainModel, \
-    ViolinPlot, ViolinItem, Results
+    VariableItem, ViolinPlot, ViolinItem, Results
 
 
 def dummy_run(data, model, _):
@@ -257,7 +257,7 @@ class TestOWExplainModel(WidgetTest):
         self.assertEqual(layout.columnCount(), 3)
         for i in range(layout.rowCount() - 1):
             item0 = layout.itemAt(i, 0).item
-            self.assertIsInstance(item0, QGraphicsSimpleTextItem)
+            self.assertIsInstance(item0, VariableItem)
             self.assertIsInstance(layout.itemAt(i, 1), ViolinItem)
         self.assertIsNone(layout.itemAt(n_rows - 1, 0))
         self.assertIsInstance(layout.itemAt(n_rows - 1, 1), pg.AxisItem)


### PR DESCRIPTION
##### Issue
Fixes #5

##### Description of changes
- Display Discrete variables in two rows
- Enable customization of the labels by using Visual Settings Dialog, e.g:
![image](https://user-images.githubusercontent.com/11465003/103206965-6e563000-48fd-11eb-9b9e-75b80f398356.png)
![image](https://user-images.githubusercontent.com/11465003/103206971-71512080-48fd-11eb-8b63-479014c81c33.png)


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation 
