### PR TITLE
Increase oldest Orange version to 3.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    "Orange3",
+    "Orange3 >= 3.27.1",
     "AnyQt",
     "numpy",
     "pyqtgraph",

--- a/tox.ini
+++ b/tox.ini
@@ -27,12 +27,10 @@ deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
     oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.25.0
+    oldest: orange3==3.27.1
     # Use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.9 ; sys_platform != 'win32'
-    oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
-    oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
-    oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
+    oldest: orange-canvas-core==0.1.18
+    oldest: orange-widget-base==4.9.0
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base


### PR DESCRIPTION
Oldest orange version for GH Actions tests is currently set to 3.25. https://github.com/biolab/orange3-explain/pull/8 introduces `customizableplot` which needs at least 3.27.0. Increasing minimal Orange version to 3.27.