### PR TITLE
Add orange-widget-base as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ DATA_FILES = [
 
 INSTALL_REQUIRES = [
     "Orange3 >= 3.27.1",
+    "orange-widget-base",
     "AnyQt",
     "numpy",
     "pyqtgraph",


### PR DESCRIPTION
Orange3-explain import orangewidget so it must be included in dependencies. 

Missing dependency was reported in https://github.com/conda-forge/orange3-explain-feedstock/pull/2#issuecomment-804330784