### PR TITLE
[FIX] Feature Importance: Handle data with no features

### DIFF
--- a/orangecontrib/explain/inspection.py
+++ b/orangecontrib/explain/inspection.py
@@ -68,6 +68,8 @@ def permutation_feature_importance(
 def _check_data(data: Table):
     if not data.domain.class_var:
         raise ValueError("Data with a target variable required.")
+    if not data.domain.attributes:
+        raise ValueError("Data with features required.")
 
 
 def _check_model(model: Model, data: Table) -> bool:

--- a/orangecontrib/explain/tests/test_inspection.py
+++ b/orangecontrib/explain/tests/test_inspection.py
@@ -234,6 +234,15 @@ class TestPermutationFeatureImportance(unittest.TestCase):
         self.assertRaises(DomainTransformationError,
                           permutation_feature_importance, *args)
 
+    def test_inadequate_data(self):
+        domain = Domain([],
+                        class_vars=self.iris.domain.class_vars,
+                        metas=self.iris.domain.attributes)
+        data = self.iris.transform(domain)
+        model = RandomForestLearner()(self.iris)
+        args = model, data, self.n_repeats
+        self.assertRaises(ValueError, permutation_feature_importance, *args)
+
     def test_inadequate_model(self):
         model = RandomForestLearner()(self.iris)
         args = model, self.housing, self.n_repeats

--- a/orangecontrib/explain/widgets/tests/test_owpermutationimportance.py
+++ b/orangecontrib/explain/widgets/tests/test_owpermutationimportance.py
@@ -80,6 +80,17 @@ class TestOWPermutationImportance(WidgetTest):
         self.assertPlotEmpty(self.widget.plot)
         self.assertTrue(self.widget.Error.unknown_err.is_shown())
 
+    def test_data_with_no_features(self):
+        domain = Domain([],
+                        class_vars=self.iris.domain.class_vars,
+                        metas=self.iris.domain.attributes)
+        data = self.iris.transform(domain)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.model, self.rf_cls)
+        self.wait_until_finished()
+        self.assertPlotEmpty(self.widget.plot)
+        self.assertTrue(self.widget.Error.unknown_err.is_shown())
+
     def test_output_scores(self):
         self.send_signal(self.widget.Inputs.data, self.iris)
         self.send_signal(self.widget.Inputs.model, self.rf_cls)


### PR DESCRIPTION
##### Issue
The `Feature Importance` widget shows an uninformative message when input data has no features.

##### Description of changes
Raise an exception with more informative message, when data has no features.