### PR TITLE
Upgrade shap to version 0.40

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ INSTALL_REQUIRES = [
     "numpy",
     "pyqtgraph",
     "scipy",
-    "shap ==0.37.*",  # shap makes significant changes between versions
+    "shap ==0.40.*",  # shap makes significant changes between versions
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
Shap 0.40.* seems to be working correctly and it also provide wheels for all OS