### PR TITLE
Explain Predictions: Better tooltips, highlight feature on hover

### DIFF
--- a/orangecontrib/explain/explainer.py
+++ b/orangecontrib/explain/explainer.py
@@ -645,7 +645,7 @@ def prepare_force_plot_data_multi_inst(
                             for s, v in exps])
         y_upper = np.array([(s - v[neg_idxs[:i + 1]].clip(max=0).sum())
                             for s, v in exps])
-        neg_data.append((y_lower, y_upper))
+        neg_data.append((y_upper, y_lower))
 
     return np.arange(shap_values.shape[0]), pos_data, neg_data
 

--- a/orangecontrib/explain/tests/test_explainer.py
+++ b/orangecontrib/explain/tests/test_explainer.py
@@ -359,7 +359,7 @@ class TestExplainer(unittest.TestCase):
 
         for i in range(len(pos_data) - 1):
             np.testing.assert_array_equal(pos_data[i][1], pos_data[i + 1][0])
-            np.testing.assert_array_equal(neg_data[i][1], neg_data[i + 1][0])
+            np.testing.assert_array_equal(neg_data[i][0], neg_data[i + 1][1])
 
         for i, (y1, y2) in enumerate([([13, -8, 15], [8, -8, 10]),
                                       ([8, -8, 10], [2, -8,  6]),
@@ -372,8 +372,8 @@ class TestExplainer(unittest.TestCase):
                                       ([15, -5, 15], [15, 0, 15]),
                                       ([15, 0, 15], [15,  2, 15]),
                                       ([15, 2, 15], [15, 3, 15])]):
-            np.testing.assert_array_equal(neg_data[i][0], y1)
-            np.testing.assert_array_equal(neg_data[i][1], y2)
+            np.testing.assert_array_equal(neg_data[i][0], y2)
+            np.testing.assert_array_equal(neg_data[i][1], y1)
 
     def test_prepare_force_plot_data_multi_inst_order(self):
         base_value = np.array([3])
@@ -397,7 +397,7 @@ class TestExplainer(unittest.TestCase):
 
         for i in range(len(pos_data) - 1):
             np.testing.assert_array_equal(pos_data[i][1], pos_data[i + 1][0])
-            np.testing.assert_array_equal(neg_data[i][1], neg_data[i + 1][0])
+            np.testing.assert_array_equal(neg_data[i][0], neg_data[i + 1][1])
 
         for i, (y1, y2) in enumerate([([15, -8, 13], [10, -8, 8]),
                                       ([10, -8, 8], [6, -8, 2]),
@@ -410,8 +410,8 @@ class TestExplainer(unittest.TestCase):
                                       ([15, -5, 15], [15, 0, 15]),
                                       ([15, 0, 15], [15,  2, 15]),
                                       ([15, 2, 15], [15, 3, 15])]):
-            np.testing.assert_array_equal(neg_data[i][0], y1)
-            np.testing.assert_array_equal(neg_data[i][1], y2)
+            np.testing.assert_array_equal(neg_data[i][0], y2)
+            np.testing.assert_array_equal(neg_data[i][1], y1)
 
     def test_prepare_force_plot_data_target_0(self):
         shap_values = [

--- a/orangecontrib/explain/tests/test_explainer.py
+++ b/orangecontrib/explain/tests/test_explainer.py
@@ -348,8 +348,8 @@ class TestExplainer(unittest.TestCase):
             shap_values[0], predictions[:, 0],
             self.iris[:3], INSTANCE_ORDERINGS[2])
 
-        x_data, pos_data, neg_data = prepare_force_plot_data_multi_inst(
-            shap_values[0][idxs], base_value[0])
+        x_data, pos_data, neg_data, _, _ = prepare_force_plot_data_multi_inst(
+            shap_values[0][idxs], base_value[0], self.iris.domain)
 
         np.testing.assert_array_equal(x_data, np.arange(3))
         self.assertEqual(len(pos_data), 4)
@@ -386,8 +386,8 @@ class TestExplainer(unittest.TestCase):
             shap_values[0], predictions[:, 0],
             self.iris[:3], self.iris.domain[0])
 
-        x_data, pos_data, neg_data = prepare_force_plot_data_multi_inst(
-            shap_values[0][idxs], base_value[0])
+        x_data, pos_data, neg_data, _, _ = prepare_force_plot_data_multi_inst(
+            shap_values[0][idxs], base_value[0], self.iris.domain)
 
         np.testing.assert_array_equal(x_data, np.arange(3))
         self.assertEqual(len(pos_data), 4)

--- a/orangecontrib/explain/widgets/owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/owexplainpredictions.py
@@ -8,7 +8,7 @@ import numpy as np
 from AnyQt.QtCore import QPointF, Qt, Signal, QRectF, QEvent
 from AnyQt.QtGui import QTransform, QPainter, QColor, QPainterPath, \
     QPolygonF, QMouseEvent
-from AnyQt.QtWidgets import QComboBox
+from AnyQt.QtWidgets import QComboBox, QApplication, QGraphicsSceneMouseEvent
 
 import pyqtgraph as pg
 from pyqtgraph.GraphicsScene.mouseEvents import MouseClickEvent, MouseDragEvent
@@ -140,9 +140,19 @@ class ForcePlotViewBox(pg.ViewBox):
         else:
             ev.ignore()
 
+    def mousePressEvent(self, ev: QGraphicsSceneMouseEvent):
+        keys = QApplication.keyboardModifiers()
+        if self.__state == SELECT and not keys & Qt.ShiftModifier:
+            ev.accept()
+            self.sigDeselect.emit()
+        super().mousePressEvent(ev)
+
     def mouseClickEvent(self, ev: MouseClickEvent):
-        ev.accept()
-        self.sigDeselect.emit()
+        if self.__state == SELECT:
+            ev.accept()
+            self.sigDeselect.emit()
+        else:
+            super().mouseClickEvent(ev)
 
 
 class ParameterSetter(CommonParameterSetter):

--- a/orangecontrib/explain/widgets/owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/owexplainpredictions.py
@@ -205,6 +205,7 @@ class ForcePlot(pg.PlotWidget):
         self.__fill_items: List[pg.FillBetweenItem] = []
         self.__text_items: List[pg.TextItem] = []
         self.__dot_items: List[pg.ScatterPlotItem] = []
+        self.__vertical_line_item: Optional[pg.InfiniteLine] = None
         self.__selection: List = []
         self.__selection_rect_items: List[SelectionRect] = []
 
@@ -302,6 +303,7 @@ class ForcePlot(pg.PlotWidget):
         self.__fill_items.clear()
         self.__text_items.clear()
         self.__dot_items.clear()
+        self.__vertical_line_item = None
         self.getViewBox().set_data_bounds(self.__data_bounds)
         self.clear()
         self._clear_selection()
@@ -401,6 +403,10 @@ class ForcePlot(pg.PlotWidget):
         px_width, px_height = view_box.viewPixelSize()
         pos = view_box.mapViewToScene(point)
         right_side = view_box.boundingRect().width() / 2 > pos.x()
+
+        self.__vertical_line_item = pg.InfiniteLine(instance_index)
+        self.addItem(self.__vertical_line_item)
+
         for rgb, labels, fill_items in ((RGB_HIGH, pos_labels, pos_fills),
                                         (RGB_LOW, neg_labels, neg_fills)):
             whiter_rgb = np.array(rgb) + (255 - np.array(rgb)) * 0.7
@@ -445,6 +451,9 @@ class ForcePlot(pg.PlotWidget):
         for item in self.__dot_items:
             self.removeItem(item)
         self.__dot_items.clear()
+        if self.__vertical_line_item is not None:
+            self.removeItem(self.__vertical_line_item)
+        self.__vertical_line_item = None
 
     def mousePressEvent(self, ev: QMouseEvent):
         self.__mouse_pressed = True

--- a/orangecontrib/explain/widgets/owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/owexplainpredictions.py
@@ -432,9 +432,10 @@ class ForcePlot(pg.PlotWidget):
                     self.__text_items.append(text_item)
                     self.addItem(text_item)
 
+                    dot_color = QColor(Qt.white)
                     dot_item = pg.ScatterPlotItem(
-                        x=[instance_index], y=[y_pos],
-                        size=4, brush=pg.mkBrush(QColor(Qt.black))
+                        x=[instance_index], y=[y_pos], size=6,
+                        pen=pg.mkPen(dot_color), brush=pg.mkBrush(dot_color)
                     )
                     self.__dot_items.append(dot_item)
                     self.addItem(dot_item)

--- a/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
@@ -74,7 +74,9 @@ class TestForcePlot(WidgetTest):
         x_data = np.arange(5)
         pos_y_data = [(np.arange(5) - 1, np.arange(5))]
         neg_y_data = [(np.arange(5), np.arange(5) + 1)]
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "", self.housing)
+        labels = [a.name for a in self.housing.domain.attributes]
+        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "",
+                           labels, labels, self.housing)
 
         # select after data is sent
         view_box.mouseDragEvent(event)
@@ -107,7 +109,9 @@ class TestForcePlot(WidgetTest):
         pos_y_data = [(np.arange(5) - 1, np.arange(5))]
         neg_y_data = [(np.arange(5), np.arange(5) + 1)]
         data = self.housing[:5, :2]
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "", data)
+        labels = [a.name for a in data.domain.attributes]
+        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "",
+                           labels, labels, data)
 
         event = Mock()
         point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))
@@ -118,7 +122,8 @@ class TestForcePlot(WidgetTest):
             "<br/><br/><b>Features</b>:<br/>CRIM = 0.02731<br/>ZN = 0.0"
         )
 
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "", data)
+        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "",
+                           labels, labels, data)
 
         event = Mock()
         point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))

--- a/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
@@ -74,7 +74,7 @@ class TestForcePlot(WidgetTest):
         x_data = np.arange(5)
         pos_y_data = [(np.arange(5) - 1, np.arange(5))]
         neg_y_data = [(np.arange(5), np.arange(5) + 1)]
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, self.housing)
+        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "", self.housing)
 
         # select after data is sent
         view_box.mouseDragEvent(event)
@@ -107,7 +107,7 @@ class TestForcePlot(WidgetTest):
         pos_y_data = [(np.arange(5) - 1, np.arange(5))]
         neg_y_data = [(np.arange(5), np.arange(5) + 1)]
         data = self.housing[:5, :2]
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, data)
+        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "", data)
 
         event = Mock()
         point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))
@@ -118,7 +118,7 @@ class TestForcePlot(WidgetTest):
             "<br/><br/><b>Features</b>:<br/>CRIM = 0.02731<br/>ZN = 0.0"
         )
 
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, data)
+        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "", data)
 
         event = Mock()
         point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))

--- a/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
@@ -97,52 +97,6 @@ class TestForcePlot(WidgetTest):
         selection_handler.assert_called_once()
         self.assertEqual(len(selection_handler.call_args[0][0]), 0)
 
-    @patch.object(QToolTip, "showText")
-    def test_tooltip(self, show_text: Mock):
-        event = Mock()
-        point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))
-        event.scenePos.return_value = point
-        self.plot.help_event(event)
-        self.assertIsNone(show_text.call_args)
-
-        x_data = np.arange(5)
-        pos_y_data = [(np.arange(5) - 1, np.arange(5))]
-        neg_y_data = [(np.arange(5), np.arange(5) + 1)]
-        data = self.housing[:5, :2]
-        labels = [a.name for a in data.domain.attributes]
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "",
-                           labels, labels, data)
-
-        event = Mock()
-        point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))
-        event.scenePos.return_value = point
-        self.plot.help_event(event)
-        self.assertEqual(
-            show_text.call_args[0][1],
-            "<br/><br/><b>Features</b>:<br/>CRIM = 0.02731<br/>ZN = 0.0"
-        )
-
-        self.plot.set_data(x_data, pos_y_data, neg_y_data, "", "",
-                           labels, labels, data)
-
-        event = Mock()
-        point = self.plot.getViewBox().mapViewToScene(QPointF(1, 2))
-        event.scenePos.return_value = point
-        self.plot.help_event(event)
-        self.assertEqual(
-            show_text.call_args[0][1],
-            "<br/><br/><b>Features</b>:<br/>CRIM = 0.02731<br/>ZN = 0.0"
-        )
-
-    def test_instance_tooltip(self):
-        domain = self.housing.domain
-        instance = self.housing[0]
-        text = "<b>Class</b>:<br/>MEDV = 24.0<br/><br/><b>Features</b>:<br/>" \
-               "CRIM = 0.00632<br/>ZN = 18.0<br/>INDUS = 2.31<br/>CHAS = 0" \
-               "<br/>NOX = 0.5380<br/>RM = 6.575<br/>AGE = 65.2<br/>" \
-               "DIS = 4.0900<br/>RAD = 1<br/>... and 4 others"
-        self.assertEqual(self.plot._instance_tooltip(domain, instance), text)
-
 
 class TestOWExplainPredictions(WidgetTest):
     @classmethod


### PR DESCRIPTION
The Explain Predictions widget is difficult to interpret, so some new features are added:
- axis labels
- highlighted feature area on hover
- tooltips shows only most important features and the hovered one
- multiple selection on Shift key pressed, extended selection rectangle