### PR TITLE
Permutation feature importance: Orange core compatibility

### DIFF
--- a/orangecontrib/explain/tests/test_inspection.py
+++ b/orangecontrib/explain/tests/test_inspection.py
@@ -67,7 +67,7 @@ class TestUtils(unittest.TestCase):
         mocked_model = Mock(wraps=model)
         baseline_score = scorer(mocked_model, data)
         mocked_model.assert_called_once()
-        self.assertAlmostEqual(baseline_score, 0.98, 3)
+        self.assertAlmostEqual(baseline_score, 0.987, 3)
 
     def test_wrap_score_predict_cls(self):
         data = self.titanic
@@ -233,7 +233,7 @@ class TestPermutationFeatureImportance(unittest.TestCase):
         model = RandomForestLearner(random_state=0)(data)
         res = permutation_feature_importance(model, data, AUC(),
                                              self.n_repeats)
-        self.assertAlmostEqual(res[0].mean(), 0.014, 3)
+        self.assertAlmostEqual(res[0].mean(), 0.013, 3)
 
     def test_auc_orange_model(self):
         data = self.titanic

--- a/orangecontrib/explain/tests/test_inspection.py
+++ b/orangecontrib/explain/tests/test_inspection.py
@@ -132,7 +132,7 @@ class TestUtils(unittest.TestCase):
         - set minimum Orange version to 3.31.0
         """
         self.assertGreater(
-            "3.33.0",
+            "3.35.0",
             pkg_resources.get_distribution("orange3").version
         )
 

--- a/orangecontrib/explain/widgets/owpermutationimportance.py
+++ b/orangecontrib/explain/widgets/owpermutationimportance.py
@@ -15,6 +15,7 @@ from Orange.data import Table, DiscreteVariable, Domain, ContinuousVariable, \
     StringVariable, HasClass
 from Orange.evaluation.scoring import Score
 from Orange.regression import RandomForestRegressionLearner
+from Orange.version import version
 from Orange.widgets import gui
 from Orange.widgets.evaluate.utils import BUILTIN_SCORERS_ORDER, usable_scorers
 from Orange.widgets.settings import Setting, ContextSetting, \
@@ -295,8 +296,14 @@ class OWPermutationImportance(OWExplainFeatureBase):
                                              Optional[Type[Score]], int]:
         score = None
         if self.model:
-            var = self.model.domain.class_var
-            score = usable_scorers(var)[self.score_index]
+            if version > "3.31.1":
+                # Eventually, keep this line (remove lines 305-306) and
+                # upgrade minimal Orange version to 3.32.0.
+                # Also remove the Orange.version import
+                score = usable_scorers(self.model.domain)[self.score_index]
+            else:
+                var = self.model.domain.class_var
+                score = usable_scorers(var)[self.score_index]
         return self.data, self.model, score, self.n_repeats
 
     # Plot setup

--- a/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
@@ -269,12 +269,12 @@ class TestOWExplainPredictions(WidgetTest):
 
         self.widget.graph.set_axis = Mock()
         simulate.combobox_activate_index(self.widget._annot_combo, 3)
-        args = ([[(0, "1"), (1, "1"), (2, "0"), (3, "0"), (4, "0")]],)
+        args = ([[(0, "0"), (1, "0"), (2, "0"), (3, "1"), (4, "1")]],)
         self.widget.graph.set_axis.assert_called_once_with(*args)
 
         self.widget.graph.set_axis.reset_mock()
         simulate.combobox_activate_index(self.widget._annot_combo, 1)
-        args = ([[(0, "2"), (1, "3"), (2, "1"), (3, "5"), (4, "4")]],)
+        args = ([[(0, "4"), (1, "5"), (2, "1"), (3, "3"), (4, "2")]],)
         self.widget.graph.set_axis.assert_called_once_with(*args)
 
         self.send_signal(self.widget.Inputs.data, None)
@@ -294,7 +294,7 @@ class TestOWExplainPredictions(WidgetTest):
         self.widget.graph.set_axis.reset_mock()
         simulate.combobox_activate_index(self.widget._annot_combo, 3)
         self.widget.graph.set_data.assert_called_once()
-        args = ([[(0, "1"), (1, "1"), (2, "0"), (3, "0"), (4, "0")]],)
+        args = ([[(0, "0"), (1, "0"), (2, "0"), (3, "1"), (4, "1")]],)
         self.widget.graph.set_axis.assert_called_once_with(*args)
 
         self.widget.graph.set_data.reset_mock()

--- a/orangecontrib/explain/widgets/tests/test_owpermutationimportance.py
+++ b/orangecontrib/explain/widgets/tests/test_owpermutationimportance.py
@@ -417,6 +417,17 @@ class TestOWPermutationImportance(WidgetTest):
         self.assertEqual(font1.pointSize(), font2.pointSize())
         self.assertEqual(font1.italic(), font2.italic())
 
+    def test_orange_version(self):
+        """
+        This test serves as a reminder.
+
+        When it starts to fail, remove it and remove the lines 18, 305 - 306 in
+        owpermutationimportance.py
+        """
+        from Orange.version import version
+
+        self.assertLess(version, "3.35.0")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,9 @@ deps =
     # Use newer canvas-core and widget-base to avoid segfaults on windows
     oldest: orange-canvas-core==0.1.18
     oldest: orange-widget-base==4.9.0
-    latest: git+git://github.com/biolab/orange3.git#egg=orange3
-    latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
-    latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
+    latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
+    latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
+    latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
 commands_pre =
     # Verify installed packages have compatible dependencies
     pip check


### PR DESCRIPTION
##### Issue
The Permutation feature importance widget stopped working after https://github.com/biolab/orange3/pull/5848.

##### Description of changes
- Enable widget for both, old and new version of Orange3
- fix tests due to https://github.com/biolab/orange3/pull/5891