### PR TITLE
ICE: Support all Orange models

### DIFF
--- a/orangecontrib/explain/tests/test_inspection.py
+++ b/orangecontrib/explain/tests/test_inspection.py
@@ -350,35 +350,6 @@ class TestIndividualConditionalExpectation(unittest.TestCase):
         self.assertEqual(res["individual"].shape, (2, 303, 41))
         self.assertEqual(res["values"].shape, (41,))
 
-    def _test_sklearn(self):
-        from matplotlib import pyplot as plt
-        from sklearn.ensemble import RandomForestClassifier, \
-            RandomForestRegressor
-        from sklearn.inspection import PartialDependenceDisplay
-
-        X = self.housing.X
-        y = self.housing.Y
-        model = RandomForestRegressor(random_state=0)
-
-        # X = self.iris.X[:100]
-        # y = self.iris.Y[:100]
-        # y = np.abs(y - 1)
-        # model = RandomForestClassifier(random_state=0)
-        model.fit(X, y)
-        display = PartialDependenceDisplay.from_estimator(
-            model,
-            X,
-            [X.shape[1] - 1],
-            target=0,
-            kind="both",
-            centered=True,
-            subsample=1000,
-            # grid_resolution=100,
-            random_state=0,
-        )
-
-        plt.show()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/explain/widgets/owice.py
+++ b/orangecontrib/explain/widgets/owice.py
@@ -15,7 +15,7 @@ import pyqtgraph as pg
 from orangecanvas.gui.utils import disconnected
 from orangewidget.utils.listview import ListViewSearch
 
-from Orange.base import Model, SklModel, RandomForestModel
+from Orange.base import Model
 from Orange.data import Table, ContinuousVariable, Variable, \
     DiscreteVariable
 from Orange.data.table import DomainTransformationError
@@ -491,7 +491,7 @@ class OWICE(OWWidget, ConcurrentWidgetMixin):
     priority = 130
 
     class Inputs:
-        model = Input("Model", (SklModel, RandomForestModel))
+        model = Input("Model", Model)
         data = Input("Data", Table)
 
     class Outputs:

--- a/orangecontrib/explain/widgets/tests/test_owice.py
+++ b/orangecontrib/explain/widgets/tests/test_owice.py
@@ -7,7 +7,7 @@ from AnyQt.QtCore import Qt, QPointF
 from Orange.classification import RandomForestLearner, CalibratedLearner, \
     ThresholdLearner
 from Orange.data import Table
-from Orange.regression import RandomForestRegressionLearner, CurveFitLearner, \
+from Orange.regression import RandomForestRegressionLearner, \
     SimpleRandomForestLearner
 from Orange.tests.test_classification import all_learners as all_cls_learners
 from Orange.tests.test_regression import all_learners as all_reg_learners, \

--- a/orangecontrib/explain/widgets/tests/test_owice.py
+++ b/orangecontrib/explain/widgets/tests/test_owice.py
@@ -4,9 +4,14 @@ from unittest.mock import Mock
 
 from AnyQt.QtCore import Qt, QPointF
 
-from Orange.classification import RandomForestLearner
+from Orange.classification import RandomForestLearner, CalibratedLearner, \
+    ThresholdLearner
 from Orange.data import Table
-from Orange.regression import RandomForestRegressionLearner
+from Orange.regression import RandomForestRegressionLearner, CurveFitLearner, \
+    SimpleRandomForestLearner
+from Orange.tests.test_classification import all_learners as all_cls_learners
+from Orange.tests.test_regression import all_learners as all_reg_learners, \
+    init_learner
 from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.explain.widgets.owice import OWICE
 
@@ -50,6 +55,30 @@ class TestOWICE(WidgetTest):
         self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
         annotated = self.get_output(self.widget.Outputs.annotated_data)
         self.assertEqual(len(annotated), len(self.heart))
+
+    def test_all_reg_models(self):
+        data = self.housing[:10]
+        self.send_signal(self.widget.Inputs.data, data)
+        for learner in all_reg_learners():
+            if issubclass(learner, (SimpleRandomForestLearner,)):
+                continue
+            learner = init_learner(learner, data)
+            model = learner(data)
+            self.send_signal(self.widget.Inputs.model, model)
+            self.wait_until_finished()
+            self.assertFalse(self.widget.Error.unknown_err.is_shown())
+
+    def test_all_cls_models(self):
+        data = self.heart[:10]
+        self.send_signal(self.widget.Inputs.data, data)
+        for learner in all_cls_learners():
+            if issubclass(learner, (CalibratedLearner, ThresholdLearner)):
+                model = learner(RandomForestLearner())(data)
+            else:
+                model = learner()(data)
+            self.send_signal(self.widget.Inputs.model, model)
+            self.wait_until_finished()
+            self.assertFalse(self.widget.Error.unknown_err.is_shown())
 
     def test_discrete_features(self):
         self.send_signal(self.widget.Inputs.data, self.titanic)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    "Orange3 >= 3.28.0",
+    "Orange3 >= 3.33.0",
     "orange-widget-base",
     "AnyQt",
     "numpy",

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,10 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.27.1
-    # Use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.18
-    oldest: orange-widget-base==4.9.0
+    oldest: scikit-learn==1.0.1
+    oldest: orange3==3.33.0
+    oldest: orange-canvas-core==0.1.27
+    oldest: orange-widget-base==4.18.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
The ICE widget works only for Logistic Regression, Linear Regression and Random Forest.

##### Description of changes
Support all models
The test should pass when https://github.com/biolab/orange3/pull/6097 is merged (and released).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation