### PR TITLE
[FIX] Workaround for missing TreeExplainer SHAP dimensions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,29 @@ on:
 jobs:
   test:
       uses: biolab/orange-ci-cd/.github/workflows/test-addons.yml@master
+  test-xgboost:
+    # On MacOS libomp is required to run XGBoost
+    name: "Test with XGBOOST"
+    runs-on: macos-latest
+    continue-on-error: false
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Install system dependencies on MacOS for xgboost
+        run: brew install libomp
+
+      - name: Test with Tox
+        run: |
+          tox -e orange-released
+        env:
+          QT_QPA_PLATFORM: offscreen

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ INSTALL_REQUIRES = [
     "numpy",
     "pyqtgraph",
     "scipy",
-    "shap ==0.40.*",  # shap makes significant changes between versions
+    "shap ==0.41.*",  # shap makes significant changes between versions
     "scikit-learn>=1.0.1",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ setenv =
 deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
+    xgboost
     oldest: scikit-learn==1.0.1
     oldest: orange3==3.33.0
     oldest: orange-canvas-core==0.1.27


### PR DESCRIPTION
##### Issues
-  TreeExplainer for XGBClassifier and GradientBoostingClassifier in case of binary classification outputs only explanation for class 1 (skipping class 0). The fix is already a PR in the SHAP library, but it does not look like it will be accepted soon (https://github.com/slundberg/shap/pull/1046).
- explain (for tree explainer) module wrongly imputes SHAP values for classes missing in the training phase. Missing explanations are always appended to the end of the list, which is wrong for cases when the missing type is not the last one.

##### Changes
- Making a workaround for missing explanation for XGBClassifier and GradientBoostingClassifier. 
- fixing imputation 
- increasing the SHAP version
- small PyQt6 compatibility fix (transforming RGB to integers)