### PR TITLE
explainer: Handle missing values when computing colors

### DIFF
--- a/orangecontrib/explain/explainer.py
+++ b/orangecontrib/explain/explainer.py
@@ -291,7 +291,7 @@ def compute_colors(data: Table) -> np.ndarray:
         normalized_x[:, max_ == min_] = 0.5
 
         v = [normalized_x * (b - a) + a for (a, b) in zip(RGB_LOW, RGB_HIGH)]
-        cont_colors = np.dstack(v).astype(int)
+        cont_colors = np.dstack(v)
 
         # missing values are imputed as gray
         return cont_colors
@@ -310,7 +310,7 @@ def compute_colors(data: Table) -> np.ndarray:
 
     # the final array is dense and we do not expect huge matrices here
     values = data.X.toarray() if sparse.issparse(data.X) else data.X
-    colors = np.zeros(values.shape + (3,), dtype=int)
+    colors = np.zeros(values.shape + (3,), dtype=float)
     is_discrete = np.array(
         [a.is_discrete for a in data.domain.attributes], dtype=bool
     )
@@ -322,7 +322,7 @@ def compute_colors(data: Table) -> np.ndarray:
     )
 
     colors[np.isnan(colors)] = 100
-    return colors
+    return colors.astype(int)
 
 
 def get_shap_values_and_colors(

--- a/orangecontrib/explain/tests/test_explainer.py
+++ b/orangecontrib/explain/tests/test_explainer.py
@@ -241,6 +241,9 @@ class TestExplainer(unittest.TestCase):
     def test_compute_colors(self):
         heart_disease = Table.from_file("heart_disease.tab")
         colors = compute_colors(heart_disease)
+        self.assertEqual(colors.dtype, int)
+        self.assertTrue((colors <= 255).all())
+        self.assertTrue((colors >= 0).all())
         self.assertTupleEqual(colors.shape, heart_disease.X.shape + (3,))
 
         # the way to add colors to attributes


### PR DESCRIPTION
##### Issue
Explain Model widget crashes when explaining models with no imputer, and data has missing values.

To reproduce:
File (Heart disease) -> Gradient Boosting (xgboost) -> Explain Model

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
