### PR TITLE
Fix test and update minimum version of SHAP

### DIFF
--- a/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
+++ b/orangecontrib/explain/widgets/tests/test_owexplainpredictions.py
@@ -233,7 +233,7 @@ class TestOWExplainPredictions(WidgetTest):
 
         self.widget.graph.set_axis.reset_mock()
         simulate.combobox_activate_index(self.widget._annot_combo, 1)
-        args = ([[(0, "4"), (1, "5"), (2, "1"), (3, "3"), (4, "2")]],)
+        args = ([[(0, "1"), (1, "5"), (2, "4"), (3, "3"), (4, "2")]],)
         self.widget.graph.set_axis.assert_called_once_with(*args)
 
         self.send_signal(self.widget.Inputs.data, None)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ INSTALL_REQUIRES = [
     "numpy",
     "pyqtgraph",
     "scipy",
-    "shap >=0.42.0",
+    "shap >=0.42.1",
     "scikit-learn>=1.0.1",
 ]
 


### PR DESCRIPTION
Set the minimum version of SHAP to 0.42.1 so that people using ARM Mac can solve their environment by updating the add-on https://github.com/biolab/orange3-explain/issues/60.

Fix the instance order in failing tests due to small changes in SHAP values.