### PR TITLE
Update requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,11 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    "Orange3 >= 3.33.0",
-    "orange-widget-base",
     "AnyQt",
     "numpy",
+    "Orange3 >= 3.33.0",
+    "orange-widget-base",
+    "orange-canvas-core",
     "pyqtgraph",
     "scipy",
     "shap >=0.42.1",


### PR DESCRIPTION
In https://github.com/conda-forge/orange3-explain-feedstock/pull/21, it was shown that the addon imports orange-canvas-core, but it is not listed as a requirement.

Adding orange-canvas-core requirement and sorting requirements