### PR TITLE
[FIX] Require numba>=0.58

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ DATA_FILES = [
 
 INSTALL_REQUIRES = [
     "AnyQt",
+    # shap's requirement, force users for numba to get updated because compatibility
+    # issues with numpy - completely remove this pin after october 2024
+    "numba >=0.58",
     "numpy",
     "Orange3 >=3.34.0",
     "orange-canvas-core >=0.1.28",

--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,12 @@ deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
     xgboost
-    oldest: scikit-learn==1.0.1
     oldest: orange3==3.34.0
     oldest: orange-canvas-core==0.1.28
     oldest: orange-widget-base==4.19.0
     oldest: pandas==1.4.0
+    oldest: scikit-learn==1.0.1
+    oldest: scipy==1.9.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     oldest: orange3==3.34.0
     oldest: orange-canvas-core==0.1.28
     oldest: orange-widget-base==4.19.0
+    oldest: pandas==1.4.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
Should fix https://github.com/biolab/orange3-explain/issues/65

There is numpy compatibility issue in one of the previous versions of numba (I think 0.57), and it is fixed in 0.58. To ensure that users do not miss widgets due to this error, I am fixing Numba to a newer version.