### PR TITLE
CI - Automated release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: biolab/orange-ci-cd/.github/workflows/release.yml@master
+    with:
+      pure-python: true
+    secrets: inherit


### PR DESCRIPTION
Closes #71 (from fork - no access to secrets)

Use reusable workflow for release